### PR TITLE
Minimalistic Persistence

### DIFF
--- a/src/persistence/KeyValueStorage.ts
+++ b/src/persistence/KeyValueStorage.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {KeyValueHandler} from "./keyvalue/KeyValueHandler";
+import {Store} from "./store/Store";
+
+export interface KeyValueStorage extends KeyValueHandler, Store {}

--- a/src/persistence/keyvalue/JsonKeyValueStore.ts
+++ b/src/persistence/keyvalue/JsonKeyValueStore.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { NoStorageMapKeyValueStore } from "./NoStorageMapKeyValueStore";
+
+interface StorageValuePair {
+    type?: string;
+    content: any;
+}
+
+interface StorageEntry {
+    key: string;
+    value: StorageValuePair;
+}
+
+interface StorageOptions {
+    noAutomaticallyStoreOnChange?: boolean;
+}
+export class JsonNoStorageMapKeyValueStore extends NoStorageMapKeyValueStore {
+
+    toJsonString(): string {
+        return JSON.stringify([...this.data].map(([key, value]) => ( { key, value })), (key, value) => {
+            if (typeof value === 'bigint') {
+                return `bigint(${value})`;
+            }
+            if (typeof value === 'object' && value.type === 'Buffer' && Array.isArray(value.data)) {
+                return `Buffer(${Buffer.from(value.data).toString('base64')})`;
+            }
+            if (value instanceof Uint8Array) {
+                return `Uint8Array(${Buffer.from(value).toString('base64')})`;
+            }
+            return value;
+        });
+    }
+
+    fromJsonString(json: string): void {
+        const mapData = JSON.parse(json, (key, value) => {
+            if (typeof value === 'string' && value.startsWith('bigint(') && value.endsWith(')')) {
+                return BigInt(value.slice(7, -1));
+            }
+            if (typeof value === 'string' && value.startsWith('Buffer(') && value.endsWith(')')) {
+                return Buffer.from(value.slice(7, -1), 'base64');
+            }
+            if (typeof value === 'string' && value.startsWith('Uint8Array(') && value.endsWith(')')) {
+                return new Uint8Array(Buffer.from(value.slice(11, -1), 'base64'));
+            }
+            return value;
+        }) as StorageEntry[];
+        console.log('decoded:', mapData);
+        mapData.forEach(entry => this.data.set(entry.key, entry.value));
+    }
+
+}

--- a/src/persistence/keyvalue/JsonKeyValueStore.ts
+++ b/src/persistence/keyvalue/JsonKeyValueStore.ts
@@ -5,19 +5,11 @@
  */
 import { NoStorageMapKeyValueStore } from "./NoStorageMapKeyValueStore";
 
-interface StorageValuePair {
-    type?: string;
-    content: any;
-}
-
 interface StorageEntry {
     key: string;
-    value: StorageValuePair;
+    value: any;
 }
 
-interface StorageOptions {
-    noAutomaticallyStoreOnChange?: boolean;
-}
 export class JsonNoStorageMapKeyValueStore extends NoStorageMapKeyValueStore {
 
     toJsonString(): string {

--- a/src/persistence/keyvalue/KeyValueHandler.ts
+++ b/src/persistence/keyvalue/KeyValueHandler.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface KeyValueHandler {
+    getContextKey(context: string, contextKey: string, defaultValue: any): any | undefined;
+    getContextKeys(context: string): any[];
+    setContextKey(context: string, contextKey: string, value: any): void;
+    setContextKeys(context: string, data: { key: string, value: any}[]): void;
+    deleteContextKey(context: string, contextKey: string): void;
+    deleteContext(context: string): void;
+}

--- a/src/persistence/keyvalue/NoStorageMapKeyValueStore.ts
+++ b/src/persistence/keyvalue/NoStorageMapKeyValueStore.ts
@@ -11,7 +11,7 @@ export class NoStorageMapKeyValueStore implements KeyValueHandler {
     constructor() {}
 
     private buildKeyString(context: string, contextKey: string): string {
-        return `${context}-${contextKey}`;
+        return `${context}$$${contextKey}`;
     }
 
     getContextKey(context: string, contextKey: string, defaultValue: any): any | undefined {
@@ -41,7 +41,7 @@ export class NoStorageMapKeyValueStore implements KeyValueHandler {
 
     deleteContext(context: string): void {
         const keys = Array.from(this.data.keys());
-        keys.filter((key) => key.startsWith(`${context}-`)).forEach((key) => this.data.delete(key));
+        keys.filter((key) => key.startsWith(`${context}$$`)).forEach((key) => this.data.delete(key));
     }
 
 }

--- a/src/persistence/keyvalue/NoStorageMapKeyValueStore.ts
+++ b/src/persistence/keyvalue/NoStorageMapKeyValueStore.ts
@@ -23,8 +23,9 @@ export class NoStorageMapKeyValueStore implements KeyValueHandler {
     }
 
     getContextKeys(context: string): { key: string, value: any}[] {
-        const keys = Array.from(this.data.keys());
-        return keys.filter((key) => key.startsWith(`${context}$$`)).map((key) => ({ key: key.substring(context.length + 1), value: this.data.get(key)}));
+return [...this.data]
+    .filter(([key]) => key.startsWith(`${context}$$`))
+    .map(([key, value]) => ({ key: key.substring(context.length + 1), value }));
     }
 
     setContextKey(context: string, contextKey: string, value: any): void {

--- a/src/persistence/keyvalue/NoStorageMapKeyValueStore.ts
+++ b/src/persistence/keyvalue/NoStorageMapKeyValueStore.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { KeyValueHandler } from "./KeyValueHandler";
+
+export class NoStorageMapKeyValueStore implements KeyValueHandler {
+    protected data = new Map<string, any>();
+
+    constructor() {}
+
+    private buildKeyString(context: string, contextKey: string): string {
+        return `${context}-${contextKey}`;
+    }
+
+    getContextKey(context: string, contextKey: string, defaultValue: any): any | undefined {
+        const value = this.data.get(this.buildKeyString(context, contextKey));
+        if (value === undefined) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    getContextKeys(context: string): { key: string, value: any}[] {
+        const keys = Array.from(this.data.keys());
+        return keys.filter((key) => key.startsWith(`${context}-`)).map((key) => ({ key: key.substring(context.length + 1), value: this.data.get(key)}));
+    }
+
+    setContextKey(context: string, contextKey: string, value: any): void {
+        this.data.set(this.buildKeyString(context, contextKey), value);
+    }
+
+    setContextKeys(context: string, data: { key: string, value: any}[]): void {
+        data.forEach((item) => this.data.set(this.buildKeyString(context, item.key), item.value));
+    }
+
+    deleteContextKey(context: string, contextKey: string): void {
+        this.data.delete(this.buildKeyString(context, contextKey));
+    }
+
+    deleteContext(context: string): void {
+        const keys = Array.from(this.data.keys());
+        keys.filter((key) => key.startsWith(`${context}-`)).forEach((key) => this.data.delete(key));
+    }
+
+}

--- a/src/persistence/keyvalue/NoStorageMapKeyValueStore.ts
+++ b/src/persistence/keyvalue/NoStorageMapKeyValueStore.ts
@@ -24,7 +24,7 @@ export class NoStorageMapKeyValueStore implements KeyValueHandler {
 
     getContextKeys(context: string): { key: string, value: any}[] {
         const keys = Array.from(this.data.keys());
-        return keys.filter((key) => key.startsWith(`${context}-`)).map((key) => ({ key: key.substring(context.length + 1), value: this.data.get(key)}));
+        return keys.filter((key) => key.startsWith(`${context}$$`)).map((key) => ({ key: key.substring(context.length + 1), value: this.data.get(key)}));
     }
 
     setContextKey(context: string, contextKey: string, value: any): void {

--- a/src/persistence/store/FakeJsonKeyValueStore.ts
+++ b/src/persistence/store/FakeJsonKeyValueStore.ts
@@ -11,16 +11,13 @@ export class FakeJsonKeyValueStore extends JsonNoStorageMapKeyValueStore impleme
     private opened = false;
 
     async open(): Promise<void> {
-        console.log('OPEN');
         this.opened = true;
     }
 
     async close(): Promise<void> {
-        console.log('CLOSE CALL');
         if (!this.opened) {
             return;
         }
-        console.log('CLOSE');
         this.opened = false;
     }
 

--- a/src/persistence/store/FakeJsonKeyValueStore.ts
+++ b/src/persistence/store/FakeJsonKeyValueStore.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { JsonNoStorageMapKeyValueStore } from "../keyvalue/JsonKeyValueStore";
+import { Store } from "./Store";
+import {KeyValueHandler} from "../keyvalue/KeyValueHandler";
+
+export class FakeJsonKeyValueStore extends JsonNoStorageMapKeyValueStore implements KeyValueHandler, Store {
+    private opened = false;
+
+    async open(): Promise<void> {
+        console.log('OPEN');
+        this.opened = true;
+    }
+
+    async close(): Promise<void> {
+        console.log('CLOSE CALL');
+        if (!this.opened) {
+            return;
+        }
+        console.log('CLOSE');
+        this.opened = false;
+    }
+
+    async persistData(): Promise<void> {
+        if (!this.opened) {
+            throw new Error("The KeyValueStore is not open");
+        }
+    }
+
+    public isOpened(): boolean {
+        return this.opened;
+    }
+
+    public getData(): Map<string, any> {
+        return this.data;
+    }
+}

--- a/src/persistence/store/NodeFsJsonKeyValueStore.ts
+++ b/src/persistence/store/NodeFsJsonKeyValueStore.ts
@@ -35,13 +35,8 @@ export class NodeFsJsonKeyValueStore extends JsonNoStorageMapKeyValueStore imple
     }
 
     scheduleDataStorage(): void {
-        if (this.options.storageDelay === -1) {
+        if (this.storageTimer || this.options.storageDelay === -1) {
             return;
-        }
-
-        if (this.storageTimer) {
-            this.storageTimer.stop();
-            this.storageTimer = null;
         }
 
         this.storageTimer = Time.getTimer(this.options.storageDelay || STORAGE_DELAY_DEFAULT, () => this.persistData()).start();

--- a/src/persistence/store/NodeFsJsonKeyValueStore.ts
+++ b/src/persistence/store/NodeFsJsonKeyValueStore.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as fs from "fs";
+import { JsonNoStorageMapKeyValueStore } from "../keyvalue/JsonKeyValueStore";
+import { Store } from "./Store";
+import { Time, Timer } from "../../time/Time";
+
+const STORAGE_DELAY_DEFAULT = 1000;
+
+interface StorageOptions {
+    /**
+     * Number of milliseconds to delay storing the data into the file to prevent storing too much when
+     * multiple data are set in a short time. Use -1 to only manually store the data by using "persistData".
+     * The default delay if not set is 1s
+     */
+    storageDelay?: number;
+}
+
+export class NodeFsJsonKeyValueStore extends JsonNoStorageMapKeyValueStore implements Store {
+    private opened = false;
+
+    private storageTimer: Timer | null = null;
+
+    constructor(
+        private readonly filePath: string,
+        private readonly options: StorageOptions = {}
+    ) {
+        super();
+        if (this.options.storageDelay === undefined || this.options.storageDelay < -1) {
+            this.options.storageDelay = STORAGE_DELAY_DEFAULT;
+        }
+    }
+
+    scheduleDataStorage(): void {
+        if (this.options.storageDelay === -1) {
+            return;
+        }
+
+        if (this.storageTimer) {
+            this.storageTimer.stop();
+            this.storageTimer = null;
+        }
+
+        this.storageTimer = Time.getTimer(this.options.storageDelay || STORAGE_DELAY_DEFAULT, () => this.persistData()).start();
+    }
+
+    getContextKey(context: string, contextKey: string, defaultValue: any): any | undefined {
+        if (!this.opened) {
+            throw new Error("The KeyValueStore is not open");
+        }
+        return super.getContextKey(context, contextKey, defaultValue);
+    }
+
+    getContextKeys(context: string): any[] {
+        if (!this.opened) {
+            throw new Error("The KeyValueStore is not open");
+        }
+        return super.getContextKeys(context);
+    }
+
+    setContextKey(context: string, contextKey: string, value: any): void {
+        if (!this.opened) {
+            throw new Error("The KeyValueStore is not open");
+        }
+        super.setContextKey(context, contextKey, value);
+        this.scheduleDataStorage();
+    }
+
+    setContextKeys(context: string, data: { key: string, value: any}[]): void {
+        if (!this.opened) {
+            throw new Error("The KeyValueStore is not open");
+        }
+        super.setContextKeys(context, data);
+        this.scheduleDataStorage();
+    }
+
+    deleteContextKey(context: string, contextKey: string): void {
+        if (!this.opened) {
+            throw new Error("The KeyValueStore is not open");
+        }
+        super.deleteContextKey(context, contextKey);
+        this.scheduleDataStorage();
+    }
+
+    deleteContext(context: string): void {
+        if (!this.opened) {
+            throw new Error("The KeyValueStore is not open");
+        }
+        super.deleteContext(context);
+        this.scheduleDataStorage();
+    }
+
+    async open(): Promise<void> {
+        this.opened = true;
+
+        if (fs.existsSync(this.filePath)) {
+            const content = fs.readFileSync(this.filePath, 'utf-8');
+            this.fromJsonString(content);
+        }
+    }
+
+    async close(): Promise<void> {
+        if (!this.opened) {
+            return;
+        }
+        await this.persistData();
+        this.opened = false;
+    }
+
+    async persistData(): Promise<void> {
+        if (!this.opened) {
+            throw new Error("The KeyValueStore is not open");
+        }
+
+        if (this.storageTimer) {
+            this.storageTimer.stop();
+            this.storageTimer = null;
+        }
+
+        const data = this.toJsonString();
+        fs.writeFileSync(this.filePath, data, 'utf-8');
+    }
+}

--- a/src/persistence/store/Store.ts
+++ b/src/persistence/store/Store.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2022 The node-matter Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface Store {
+    open(): Promise<void>;
+    close(): Promise<void>;
+    persistData(): Promise<void>;
+}


### PR DESCRIPTION
This is a first minimalistic Persistence implementation. It uses a Map internally with a "context" key structure and allows to be stored a JSON and one implementation saves the data using Nodejs FS, but all splitted up sp that a Browser implementation could "just" store the JSON differently.

The storage also preserves bigint, Buffer and Uint8Arrays and restores them correctly.